### PR TITLE
Dissable right click

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -44,6 +44,8 @@
 </head>
 <body>
     <script type="module">
+        document.addEventListener('contextmenu', event => event.preventDefault());
+        
         import init from "./<!<!PROJECT_NAME!>!>.js";
 
         async function load(wasmPath) {


### PR DESCRIPTION
You will want this if your game uses a right-click because normally it won't be sent to the wasm but if you do this it will.